### PR TITLE
feat: show volume and outcome prices in market alerts

### DIFF
--- a/lib/polymarket.ts
+++ b/lib/polymarket.ts
@@ -217,7 +217,34 @@ export function formatMessage(event: PolymarketEvent): string {
   const escapedTitle = escapeMarkdown(event.title);
   const endDate = formatDate(event.endDate);
 
+  // Volume
+  let volumeText = "";
+  const vol = parseFloat(event.volume || "0");
+  if (vol > 0) {
+    const formatted = vol.toLocaleString("en-US", {
+      style: "currency",
+      currency: "USD",
+      maximumFractionDigits: 0,
+    });
+    volumeText = `\n💰 Volume: ${escapeMarkdown(formatted)}`;
+  }
+
+  // Outcome prices from the first market
+  let pricesText = "";
+  if (event.markets?.[0]?.outcomePrices) {
+    try {
+      const prices = JSON.parse(event.markets[0].outcomePrices);
+      if (prices.length >= 2) {
+        const yesPrice = (parseFloat(prices[0]) * 100).toFixed(0);
+        const noPrice = (parseFloat(prices[1]) * 100).toFixed(0);
+        pricesText = `\n📊 Yes: ${yesPrice}% / No: ${noPrice}%`;
+      }
+    } catch {
+      // Skip prices if parsing fails
+    }
+  }
+
   return `🆕 *${escapedTitle}*\n\n` +
-    `⏰ ${escapeMarkdown(endDate)}\n\n` +
+    `⏰ ${escapeMarkdown(endDate)}${pricesText}${volumeText}\n\n` +
     `🔗 [View on Polymarket](${url})`;
 }


### PR DESCRIPTION
## Summary
Adds volume (USD) and Yes/No outcome prices to the serverless market alert messages. The local bot version already showed this data, but the Vercel deployment — the recommended mode — only sent title and end date. Now users can immediately gauge market interest and current odds from the notification itself.

## Changes
- `lib/polymarket.ts` — `formatMessage` now includes volume (formatted as USD) and outcome prices (Yes/No percentages) parsed from the first market's `outcomePrices` field. Both degrade gracefully (skipped if data is zero/missing/unparseable).

## Context
The serverless format was stripped down compared to the local version. For a prediction market alert bot, volume and odds are the two most useful data points — they determine whether a market is worth clicking through to.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)