### PR TITLE
fix: drop reverse substring check in shouldShowEvent filter

### DIFF
--- a/lib/polymarket.ts
+++ b/lib/polymarket.ts
@@ -144,7 +144,7 @@ export function shouldShowEvent(event: PolymarketEvent, hiddenCategories: Filter
 
   for (const category of hiddenCategories) {
     const categoryLower = category.toLowerCase();
-    if (eventTags.some((tag) => tag.includes(categoryLower) || categoryLower.includes(tag))) {
+    if (eventTags.some((tag) => tag.includes(categoryLower))) {
       return false;
     }
   }


### PR DESCRIPTION
## Summary
`shouldShowEvent` did a bidirectional `includes()` check between tag labels and category names. The reverse direction (`categoryLower.includes(tag)`) silently hid events whenever a tag was a substring of a category name — including the empty string `""`, which is a substring of every category. A single missing/blank tag label in the Polymarket API response would hide that event from every filter.

## Changes
- `lib/polymarket.ts` — Drop `categoryLower.includes(tag)` from `shouldShowEvent`. Keep `tag.includes(categoryLower)` (the intentional broader-match direction — "Esports" matched by "Sports", "Geopolitics" by "Politics", "US Politics" by "Politics").

## Context
Found while reading the filter handler end-to-end. Concrete regressions in the old code:
- `event.tags = [{label: ""}]` + any hidden category → event hidden under all of them (`"crypto".includes("") === true` etc.)
- `event.tags = [{label: "fi"}]` + Finance hidden → hidden (`"finance".includes("fi") === true`)
- `event.tags = [{label: "po"}]` + Politics or Sports hidden → hidden

Verified with a 10-case JS table: all intentional matches (Crypto, Esports↔Sports, Geopolitics↔Politics, US Politics↔Politics) still hide as before; the three buggy cases above now correctly show.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)