### PR TITLE
fix: validate X-Telegram-Bot-Api-Secret-Token on webhook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,12 @@ TELEGRAM_BOT_TOKEN=your-bot-token-here
 # Optional: Cron secret for securing the cron endpoint
 CRON_SECRET=your-random-secret-here
 
+# Optional: Telegram webhook secret token (A-Z, a-z, 0-9, _, -; 1-256 chars).
+# Pass the same value to setWebhook via `secret_token` — Telegram echoes it
+# back in the X-Telegram-Bot-Api-Secret-Token header on every webhook call.
+# Without this, anyone who knows the webhook URL can forge updates.
+TELEGRAM_WEBHOOK_SECRET=your-random-webhook-secret-here
+
 # Upstash Redis credentials (from https://console.upstash.com)
 UPSTASH_REDIS_REST_URL=https://xxx.upstash.io
 UPSTASH_REDIS_REST_TOKEN=your-token-here

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ cp .env.example .env
 |----------|-------------|----------|
 | `TELEGRAM_BOT_TOKEN` | Bot token from @BotFather | Yes |
 | `CRON_SECRET` | Random secret to secure the cron endpoint | Recommended |
+| `TELEGRAM_WEBHOOK_SECRET` | Secret token validated against the `X-Telegram-Bot-Api-Secret-Token` header on every webhook request | Recommended |
 | `UPSTASH_REDIS_REST_URL` | Upstash Redis REST URL | Serverless only |
 | `UPSTASH_REDIS_REST_TOKEN` | Upstash Redis REST token | Serverless only |
 
@@ -90,6 +91,13 @@ Replace `YOUR_BOT_TOKEN` and `YOUR_VERCEL_URL`:
 
 ```bash
 curl "https://api.telegram.org/botYOUR_BOT_TOKEN/setWebhook?url=YOUR_VERCEL_URL/api/webhook"
+```
+
+If you set `TELEGRAM_WEBHOOK_SECRET`, pass the same value as `secret_token` so
+Telegram echoes it back in the `X-Telegram-Bot-Api-Secret-Token` header:
+
+```bash
+curl "https://api.telegram.org/botYOUR_BOT_TOKEN/setWebhook?url=YOUR_VERCEL_URL/api/webhook&secret_token=YOUR_WEBHOOK_SECRET"
 ```
 
 ### Running locally (alternative)

--- a/api/webhook.ts
+++ b/api/webhook.ts
@@ -12,6 +12,7 @@ import {
 
 const TELEGRAM_TOKEN = process.env.TELEGRAM_BOT_TOKEN!;
 const TELEGRAM_API = `https://api.telegram.org/bot${TELEGRAM_TOKEN}`;
+const WEBHOOK_SECRET = process.env.TELEGRAM_WEBHOOK_SECRET;
 
 interface TelegramUpdate {
   message?: {
@@ -124,6 +125,14 @@ async function answerCallbackQuery(callbackQueryId: string, text?: string): Prom
 }
 
 export async function POST(request: Request) {
+  // Verify Telegram webhook secret (optional but recommended)
+  if (WEBHOOK_SECRET) {
+    const headerSecret = request.headers.get("x-telegram-bot-api-secret-token");
+    if (headerSecret !== WEBHOOK_SECRET) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+  }
+
   try {
     const update: TelegramUpdate = await request.json();
 


### PR DESCRIPTION
## Summary

The Vercel webhook endpoint accepts unauthenticated POSTs. Anyone who learns the URL (it's discoverable from the deployment) can forge Telegram updates: subscribe arbitrary chat IDs, toggle their filter settings, or trigger the `/start` latest-markets spam flood against another user's chat.

## Changes

- `api/webhook.ts` — optional `TELEGRAM_WEBHOOK_SECRET` env var. When set, the handler validates `X-Telegram-Bot-Api-Secret-Token` and returns 401 on mismatch. Unset = no-op (backwards compatible).
- `.env.example` — new var documented.
- `README.md` — env table entry + setWebhook example with `secret_token`.

## Context

Mirrors the existing `CRON_SECRET` shape that already protects `api/cron.ts` — same optional-but-recommended pattern. Telegram explicitly supports this header via the `secret_token` parameter on `setWebhook` (1-256 chars, `A-Z a-z 0-9 _ -`).

`npx tsc -p tsconfig.json --noEmit` clean. No new dependencies. +23 lines across 3 files.

---
Built by [Aeon](https://github.com/aaronjmars/aeon-aaron)
