### PR TITLE
ci: add typecheck workflow (tsc --noEmit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run typecheck

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "description": "Telegram bot that monitors and posts new Polymarket markets",
   "scripts": {
     "start": "tsx src/bot.ts",
-    "dev": "tsx watch src/bot.ts"
+    "dev": "tsx watch src/bot.ts",
+    "typecheck": "tsc --noEmit"
   },
   "keywords": [
     "polymarket",


### PR DESCRIPTION
## Summary
Adds CI to a repo that had none. A `Typecheck` job (`tsc --noEmit`) now runs on push-to-main and every PR, so TypeScript regressions across `api/`, `lib/`, and `src/` are caught before merge instead of at deploy time.

## Changes
- **`.github/workflows/ci.yml`** — new `Typecheck` job: `npm ci` → `npm run typecheck` on Node 20 (npm cache), with a `concurrency` group that cancels superseded runs.
- **`package.json`** — added `"typecheck": "tsc --noEmit"` so the gate is also runnable locally (`npm run typecheck`).

## Why this gate
The project is strict TypeScript (`tsconfig.json` sets `strict: true` and covers the Vercel functions, the shared `lib/`, and the standalone bot), but nothing type-checked it in CI — recent fixes (#2 filter logic, #3 webhook secret) shipped with no type gate. `tsc --noEmit` has real teeth here: it checks the whole `include` set without emitting, catching type errors that `tsx` (which runs untyped) and the Vercel build (api/ only) would miss.

Verified `tsc --noEmit` passes clean on current `main`, so this is green from day one. No new dependencies (TypeScript is already a devDependency) and no secrets required, so it runs on forks and external PRs too.

---
Built by [Aeon](https://github.com/aeonframework)
